### PR TITLE
Fix truncated handlers and add import tests

### DIFF
--- a/handlers/age_handler.py
+++ b/handlers/age_handler.py
@@ -75,3 +75,4 @@ def register_handlers(bot: telebot.TeleBot):
         )
         bot.set_state(user_id, SurveyStates.main_menu, call.message.chat.id)
 
+

--- a/handlers/consent_handler.py
+++ b/handlers/consent_handler.py
@@ -45,3 +45,4 @@ def register_handlers(bot: telebot.TeleBot):
                                   reply_markup=None)
         # bot.edit_message_reply_markup(user_id, call.message.message_id, reply_markup=None)
 
+

--- a/handlers/delete_me_handler.py
+++ b/handlers/delete_me_handler.py
@@ -22,3 +22,4 @@ def register_handlers(bot: telebot.TeleBot):
         else:
             bot.send_message(user_id, "ℹ️ No data found to delete.")
 
+

--- a/handlers/depression_handler.py
+++ b/handlers/depression_handler.py
@@ -18,3 +18,5 @@ def register_handlers(bot: telebot.TeleBot):
                               text=get_translation(user_id, "depression_selection"),
                               parse_mode="HTML",
                               reply_markup=main_menu(user_id))
+
+

--- a/handlers/depressive_handler.py
+++ b/handlers/depressive_handler.py
@@ -18,3 +18,4 @@ def register_handlers(bot: telebot.TeleBot):
                               text=get_translation(user_id, "depressive_selection"),
                               parse_mode="HTML",
                               reply_markup=main_menu(user_id))
+

--- a/handlers/gender_handler.py
+++ b/handlers/gender_handler.py
@@ -45,3 +45,4 @@ def register_handlers(bot: telebot.TeleBot):
 
 
 
+

--- a/handlers/goto_handler.py
+++ b/handlers/goto_handler.py
@@ -20,8 +20,15 @@ def register_handlers(bot: telebot.TeleBot):
                                   parse_mode="HTML",
                                   reply_markup=age_range_menu(user_id))
         elif page == "goto_main_menu":
-            bot.edit_message_text(chat_id=call.message.chat.id,
-                                  message_id=call.message.message_id,
-                                  text=get_translation(user_id, "welcome_message")+"\n\n"+get_translation(user_id, "main_menu_message"),
-                                  parse_mode="HTML",
-                                  reply_markup=main_menu(user_id))
+            bot.edit_message_text(
+                chat_id=call.message.chat.id,
+                message_id=call.message.message_id,
+                text=get_translation(user_id, "welcome_message")
+                + "\n\n"
+                + get_translation(user_id, "main_menu_message"),
+                parse_mode="HTML",
+                reply_markup=main_menu(user_id),
+            )
+        else:
+            bot.answer_callback_query(call.id)
+

--- a/handlers/help_handler.py
+++ b/handlers/help_handler.py
@@ -2,8 +2,8 @@ import telebot
 from utils.storage import get_translation
 
 
-def register_handlers(bot: telebot.TeleBot):
-    @bot.message_handler(commands=['help'])
-    def handle_help(message):
+def register_handlers(bot: telebot.TeleBot) -> None:
+    @bot.message_handler(commands=["help"])
+    def handle_help(message: telebot.types.Message) -> None:
         user_id = message.chat.id
-        bot.send_message(user_id, get_translation(user_id, "help"), parse_mode='HTML')
+        bot.send_message(user_id, get_translation(user_id, "help"), parse_mode="HTML")

--- a/handlers/language_handler.py
+++ b/handlers/language_handler.py
@@ -46,3 +46,4 @@ def register_handlers(bot: telebot.TeleBot):
                                   reply_markup=language_menu())
             bot.set_state(user_id, SurveyStates.language, call.message.chat.id)
 
+

--- a/handlers/main_menu_handler.py
+++ b/handlers/main_menu_handler.py
@@ -59,3 +59,4 @@ def register_handlers(bot: telebot.TeleBot):
             pass
 
 
+

--- a/handlers/phq9_survey_handler.py
+++ b/handlers/phq9_survey_handler.py
@@ -58,3 +58,4 @@ def register_handlers(bot: telebot.TeleBot):
             context.set_user_info_field(user_id, "message_to_del", message_id)
             bot.set_state(user_id, SurveyStates.wbmms, call.message.chat.id)
 
+

--- a/handlers/profile_handler.py
+++ b/handlers/profile_handler.py
@@ -3,10 +3,11 @@ from utils.storage import get_user_profile
 from utils.menu import profile_menu
 
 
+def register_handlers(bot: telebot.TeleBot) -> None:
+    """Register profile callbacks."""
 
-def register_handlers(bot: telebot.TeleBot):
     @bot.callback_query_handler(func=lambda call: call.data.startswith("profile_"))
-    def handle_profile_response(call):
+    def handle_profile_response(call: telebot.types.CallbackQuery) -> None:
         user_id = call.message.chat.id
         command = call.data.split("_")[1]
         if command == "open":
@@ -14,6 +15,9 @@ def register_handlers(bot: telebot.TeleBot):
                 chat_id=call.message.chat.id,
                 message_id=call.message.message_id,
                 text=get_user_profile(user_id),
-                parse_mode='HTML',
+                parse_mode="HTML",
                 reply_markup=profile_menu(user_id),
             )
+        else:
+            bot.answer_callback_query(call.id)
+

--- a/handlers/start_handler.py
+++ b/handlers/start_handler.py
@@ -46,3 +46,4 @@ def register_handlers(bot: telebot.TeleBot):
                              parse_mode='HTML',
                              reply_markup=main_menu(user_id))
 
+

--- a/handlers/treatment_handler.py
+++ b/handlers/treatment_handler.py
@@ -18,3 +18,4 @@ def register_handlers(bot: telebot.TeleBot):
                               text=get_translation(user_id, "treatment_selection"),
                               parse_mode="HTML",
                               reply_markup=depressive_menu(user_id))
+

--- a/handlers/voice_handler.py
+++ b/handlers/voice_handler.py
@@ -64,3 +64,4 @@ def register_handlers(bot: telebot.TeleBot):
         #     context.set_user_info_field(user_id, "current_question_index", current_question + 1)
         #     logger.log_event(user_id, f"VOICE WBMMS QUESTION {current_question}", f"answer {filename}")
         #     ask_next_main_question(bot, user_id)
+

--- a/handlers/wbmms_survey_handler.py
+++ b/handlers/wbmms_survey_handler.py
@@ -105,3 +105,4 @@ def register_handlers(bot: telebot.TeleBot):
             bot.send_message(user_id, get_translation(user_id, "error_message"))
             bot.send_message(user_id, get_translation(user_id, "end_main_survey_message"))
 
+

--- a/tests/test_handlers_import.py
+++ b/tests/test_handlers_import.py
@@ -1,0 +1,90 @@
+import importlib
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+# Provide a minimal stub for telebot so modules import correctly
+sys.modules.setdefault(
+    "telebot",
+    SimpleNamespace(
+        TeleBot=object,
+        types=SimpleNamespace(
+            Message=object,
+            CallbackQuery=object,
+            InlineKeyboardMarkup=object,
+            InlineKeyboardButton=object,
+        ),
+        handler_backends=SimpleNamespace(StatesGroup=object, State=object),
+    ),
+)
+sys.modules.setdefault(
+    "telebot.types",
+    sys.modules["telebot"].types,
+)
+sys.modules.setdefault(
+    "telebot.handler_backends",
+    sys.modules["telebot"].handler_backends,
+)
+
+sys.modules.setdefault("numpy", SimpleNamespace())
+sys.modules.setdefault("pandas", SimpleNamespace())
+
+class DummyBot:
+    def callback_query_handler(self, *args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
+
+    def message_handler(self, *args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
+
+    def set_state(self, *args, **kwargs):
+        pass
+
+    def edit_message_text(self, *args, **kwargs):
+        pass
+
+    def send_message(self, *args, **kwargs):
+        pass
+
+    def delete_state(self, *args, **kwargs):
+        pass
+
+    def retrieve_data(self, *args, **kwargs):
+        from contextlib import contextmanager
+        @contextmanager
+        def cm():
+            yield {}
+        return cm()
+
+handlers = [
+    'profile_handler',
+    'age_handler',
+    'goto_handler',
+    'start_handler',
+    'help_handler',
+    'delete_me_handler',
+    'gender_handler',
+    'consent_handler',
+    'language_handler',
+    'treatment_handler',
+    'depression_handler',
+    'depressive_handler',
+    'main_menu_handler',
+    'phq9_survey_handler',
+    'wbmms_survey_handler',
+    'voice_handler',
+]
+
+
+def test_register_handlers():
+    bot = DummyBot()
+    for mod_name in handlers:
+        module = importlib.import_module(f'handlers.{mod_name}')
+        assert hasattr(module, 'register_handlers')
+        module.register_handlers(bot)


### PR DESCRIPTION
## Summary
- close off truncated handler files with minimal logic
- ensure `register_handlers` functions are well-defined
- add unit test that imports each handler

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859ab7565a08331927b7ff2cb62093c